### PR TITLE
Update ConsoleHost_history.txt collection code

### DIFF
--- a/HostEnum.ps1
+++ b/HostEnum.ps1
@@ -953,7 +953,12 @@ Local filesystem enumeration
 
     # Get Powershell History
     "`n[+] Current User Powershell Console History:`n`n"
-    (Get-Content $ENV:APPDATA\Microsoft\Windows\PowerShell\PSReadline\ConsoleHost_history.txt -EA 0 |select -last 50) -join "`r`n"
+    Try {
+        $PowershellHistory = (Get-PSReadlineOption).HistorySavePath
+        (Get-Content $PowershellHistory -EA 0 |select -last 50) -join "`r`n"
+    } Catch [System.Management.Automation.CommandNotFoundException]{
+        (Get-Content $ENV:APPDATA\Microsoft\Windows\PowerShell\PSReadline\ConsoleHost_history.txt -EA 0 |select -last 50) -join "`r`n"
+    }
     
     # Get Host File
     "`n[+] Contents of Hostfile:`n`n"


### PR DESCRIPTION
The default location of ConsoleHost_history.txt is $env:APPDATA\Microsoft\Windows\PowerShell\PSReadLine\ConsoleHost_history.txt.

But the really reliable path is stored in (Get-PSReadlineOption).HistorySavePath
